### PR TITLE
Allow user group mapping

### DIFF
--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -151,6 +151,22 @@ SilverStripe\SAML\Extensions\SAMLMemberExtension:
     'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Email'
 ```
 
+### User groups mapping
+
+By default, any new users logged in using SSO will not have any groups assigned to them. If you want them to have want to bring over the groups from the Provider via claims field, you could enable it via
+
+```yml
+SilverStripe\SAML\Services\SAMLConfiguration:
+  map_user_group: true
+```
+
+and specify the claims field to map
+
+```yml
+SilverStripe\SAML\Helpers\SAMLUserGroupMapper:
+  group_claims_field: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups'
+```
+
 ### GUID Transformation
 
 If you prefer to receive the GUID in lower-case or upper-case format you can use the
@@ -391,6 +407,14 @@ SilverStripe\SAML\Services\SAMLConfiguration:
 
 this configuration allows you to add two GET query parameters to endpoint request URL:
 `https://your-idp.com/singleSignOnService/saml2?someGetQueryParameter=value&AnotherParameter=differentValue&SAMLRequest=XYZ....`
+
+### Automatically redirect after authentication
+If the user has CMS permission and you want to redirect to the CMS after successful authentication, you can set the default login destination like this:
+
+```yaml
+SilverStripe\Security\Security:
+  default_login_dest: 'admin'
+```
 
 ## Resources
 

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -21,6 +21,7 @@ We assume ADFS 2.0 or greater is used as an IdP.
   - [Service Provider (SP)](#service-provider-sp)
   - [Identity Provider (IdP)](#identity-provider-idp)
   - [Additional configuration for Azure AD](#additional-configuration-for-azure-ad)
+  - [User groups mapping](#user-groups-mapping)
   - [GUID Transformation](#guid-transformation)
 - [Establish trust](#establish-trust)
 - [Configure SilverStripe Authenticators](#configure-silverstripe-authenticators)
@@ -37,6 +38,7 @@ We assume ADFS 2.0 or greater is used as an IdP.
   - [Adjust the requested AuthN contexts](#adjust-the-requested-authn-contexts)
   - [Create your own SAML configuration for completely custom settings](#create-your-own-saml-configuration-for-completely-custom-settings)
   - [Additional GET Query Params for SAML](#additional-get-query-params-for-saml)
+  - [Automatically redirect after authentication](#automatically-redirect-after-authentication)
 - [Resources](#resources)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -153,7 +155,7 @@ SilverStripe\SAML\Extensions\SAMLMemberExtension:
 
 ### User groups mapping
 
-By default, any new users logged in using SSO will not have any groups assigned to them. If you want them to have want to bring over the groups from the Provider via claims field, you could enable it via
+By default, any new users logged in using SSO will not have any groups assigned to them. User groups can be enabled via
 
 ```yml
 SilverStripe\SAML\Services\SAMLConfiguration:
@@ -409,7 +411,7 @@ this configuration allows you to add two GET query parameters to endpoint reques
 `https://your-idp.com/singleSignOnService/saml2?someGetQueryParameter=value&AnotherParameter=differentValue&SAMLRequest=XYZ....`
 
 ### Automatically redirect after authentication
-If the user has CMS permission and you want to redirect to the CMS after successful authentication, you can set the default login destination like this:
+If the user has CMS permission and you want to redirect to the CMS after successful authentication, you can set the default login destination via:
 
 ```yaml
 SilverStripe\Security\Security:

--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -6,27 +6,28 @@ use Exception;
 
 use function gmmktime;
 
+use function uniqid;
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Constants;
-use OneLogin\Saml2\Utils;
 use OneLogin\Saml2\Error;
+use OneLogin\Saml2\Utils;
 use Psr\Log\LoggerInterface;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\SAML\Authenticators\SAMLAuthenticator;
 use SilverStripe\SAML\Authenticators\SAMLLoginForm;
 use SilverStripe\SAML\Helpers\SAMLHelper;
-use SilverStripe\Control\Controller;
-use SilverStripe\Control\Director;
-use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Core\Injector\Injector;
+use SilverStripe\SAML\Helpers\SAMLUserGroupMapper;
 use SilverStripe\SAML\Model\SAMLResponse;
 use SilverStripe\SAML\Services\SAMLConfiguration;
 use SilverStripe\Security\IdentityStore;
+
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-
-use function uniqid;
 
 /**
  * Class SAMLController
@@ -202,6 +203,14 @@ class SAMLController extends Controller
             }
 
             $member->$field = $attributes[$claim][0];
+        }
+
+        $mapUserGroup = Config::inst()->get(SAMLConfiguration::class, 'map_user_group');
+        // Map user groups
+        if ($mapUserGroup) {
+            $mapper = SAMLUserGroupMapper::singleton();
+
+            $member = $mapper->map($attributes, $member);
         }
 
         $member->SAMLSessionIndex = $auth->getSessionIndex();

--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -5,7 +5,6 @@ namespace SilverStripe\SAML\Control;
 use Exception;
 
 use function gmmktime;
-
 use function uniqid;
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Constants;
@@ -25,7 +24,6 @@ use SilverStripe\SAML\Helpers\SAMLUserGroupMapper;
 use SilverStripe\SAML\Model\SAMLResponse;
 use SilverStripe\SAML\Services\SAMLConfiguration;
 use SilverStripe\Security\IdentityStore;
-
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 

--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -203,14 +203,6 @@ class SAMLController extends Controller
             $member->$field = $attributes[$claim][0];
         }
 
-        $mapUserGroup = Config::inst()->get(SAMLConfiguration::class, 'map_user_group');
-        // Map user groups
-        if ($mapUserGroup) {
-            $mapper = SAMLUserGroupMapper::singleton();
-
-            $member = $mapper->map($attributes, $member);
-        }
-
         $member->SAMLSessionIndex = $auth->getSessionIndex();
 
         // This will trigger LDAP update through LDAPMemberExtension::memberLoggedIn, if the LDAP module is installed.
@@ -218,6 +210,14 @@ class SAMLController extends Controller
         // IdentityStore->logIn() is called, otherwise the identity store throws an exception.
         // Both SAML and LDAP identify Members by the same GUID field.
         $member->write();
+
+        $mapUserGroup = Config::inst()->get(SAMLConfiguration::class, 'map_user_group');
+        // Map user groups
+        if ($mapUserGroup) {
+            $mapper = SAMLUserGroupMapper::singleton();
+
+            $member = $mapper->map($attributes, $member);
+        }
 
         // Hook for modifying login behaviour
         $this->extend('updateLogin');

--- a/src/Helpers/SAMLUserGroupMapper.php
+++ b/src/Helpers/SAMLUserGroupMapper.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SilverStripe\SAML\Helpers;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\SAML\Services\SAMLConfiguration;
+use SilverStripe\Security\Group;
+use SilverStripe\Security\Member;
+
+class SAMLUserGroupMapper
+{
+    use Injectable;
+    use Configurable;
+
+    /**
+     * @var string
+     */
+    private static $group_claims_field;
+
+    /**
+     * @var array
+     */
+    private static $dependencies = [
+        'SAMLConfService' => '%$' . SAMLConfiguration::class,
+    ];
+
+    public function map($attributes, $member): Member
+    {
+        $groups = $this->config()->get('group_claims_field');
+
+        if (!isset($attributes[$groups])) {
+            return $member;
+        }
+
+        // Get groups from saml response
+        $groupTitles = $attributes[$groups];
+
+        foreach ($groupTitles as $groupTitle) {
+            // Get Group object by Title
+            // TODO: Title for Group should be unique
+            $group = DataObject::get_one(Group::class, [
+                '"Group"."Title"' => $groupTitle
+            ]);
+
+            if (!$group) {
+                $group = new Group();
+                $group->Title = $groupTitle;
+                $group->write();
+            }
+
+            $member->write();
+            $member->Groups()->add($group);
+        }
+
+        return $member;
+    }
+}

--- a/src/Helpers/SAMLUserGroupMapper.php
+++ b/src/Helpers/SAMLUserGroupMapper.php
@@ -57,11 +57,6 @@ class SAMLUserGroupMapper
                 $group->write();
             }
 
-            // Add group to user and make sure user has been created
-            if (!$member->exists()) {
-                $member->write();
-            }
-
             $member->Groups()->add($group);
         }
 

--- a/src/Helpers/SAMLUserGroupMapper.php
+++ b/src/Helpers/SAMLUserGroupMapper.php
@@ -26,6 +26,13 @@ class SAMLUserGroupMapper
         'SAMLConfService' => '%$' . SAMLConfiguration::class,
     ];
 
+    /**
+     * Check if group claims field is set and assigns member to group
+     *
+     * @param [] $attributes
+     * @param Member $member
+     * @return Member
+     */
     public function map($attributes, $member): Member
     {
         $groups = $this->config()->get('group_claims_field');
@@ -39,18 +46,22 @@ class SAMLUserGroupMapper
 
         foreach ($groupTitles as $groupTitle) {
             // Get Group object by Title
-            // TODO: Title for Group should be unique
             $group = DataObject::get_one(Group::class, [
                 '"Group"."Title"' => $groupTitle
             ]);
 
+            // Create group if it doesn't exist yet
             if (!$group) {
                 $group = new Group();
                 $group->Title = $groupTitle;
                 $group->write();
             }
 
-            $member->write();
+            // Add group to user and make sure user has been created
+            if (!$member->exists()) {
+                $member->write();
+            }
+
             $member->Groups()->add($group);
         }
 


### PR DESCRIPTION
This will allow group mapping enable if needed via

```yml
SilverStripe\SAML\Services\SAMLConfiguration:
  map_user_group: true
```

and then specify the group claims field

```yml
SilverStripe\SAML\Helpers\SAMLUserGroupMapper:
  group_claims_field: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups'
```